### PR TITLE
Fix height of .header-nav to match padding-top on body

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1395,7 +1395,7 @@ ul.heading-list .hlink:before {
   top: 0;
   right: 0;
   left: 0;
-  height: 88px;
+  height: 64px;
   line-height: 40px;
   text-align: center;
 }


### PR DESCRIPTION
This fixes a `pointer-events : none` bug caused by the `.header-nav` overflowing over the first line of text of the documentation. Any links in the first line couldn't be clicked on, for example.