### PR TITLE
Move menu above content

### DIFF
--- a/data/layout.jade
+++ b/data/layout.jade
@@ -98,10 +98,10 @@ html
   body.-menu-visible
     .doc-layout
       .toggle.menu-toggle.js-menu-toggle
+      .menu.toc-menu
+        +menu(toc, 0)
       .body(class=('page-' + slug))
         +header-nav
         .markdown-body
           != contents
         +footer-nav(prev, next)
-      .menu.toc-menu
-        +menu(toc, 0)


### PR DESCRIPTION
This allows mobile users better access, otherwise there is no icon and no menu.
The user would have to know to scroll down to the bottom to know there was a nav.