### PR TITLE
Remove search icon from template

### DIFF
--- a/data/style.styl
+++ b/data/style.styl
@@ -247,27 +247,6 @@ ul.heading-list
     color: $accent
     // transition: width 0 linear 250ms, background-color 0 linear 250ms, color 100ms linear
 
-//
-// Search (to do)
-//
-
-.toc-menu
-  &:before
-    ion-icon('ios-search-strong', 20px)
-    display: block
-    width: 40px
-    height: 40px
-    line-height: 40px
-    text-align: center
-
-    position: absolute
-    right: 24px - 14px
-    top: 24px - 8px
-    color: $slate
-    transition: color 400ms linear
-    border-radius: 3px
-    z-index: 10
-    cursor: pointer
 
 .header-nav,
 .footer-nav


### PR DESCRIPTION
We discussed removing search since it was never fully implemented and only raises questions. This was mentioned here: https://github.com/docpress/docpress/issues/38

This is one part of that removal.