### PR TITLE
Add Option to add user scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,20 @@ function addJs (files, ms, done) {
     files['assets/script.js'] = { contents }
     this.scripts.push('assets/script.js?t=' +
       hash(files['assets/script.js'].contents))
+
+    // Add user's files
+    let scripts = ms.metadata()
+
+    if (Array.isArray(scripts)) {
+      let userScripts = scripts.map((location) => {
+        let file = files[location]
+        if (!file.contents) return
+        let fileHash = hash(file.contents)
+        return `${location}?t=${fileHash}`
+      }).filter((url) => !!url)
+      this.scripts = this.scripts.concat(userScripts)
+    }
+
     done()
   }
 


### PR DESCRIPTION
In `docpress.json` you can specify a `scripts` option:

```json
{
  "scripts": [
    "assets/piwik.js"
  ]
}
```

The scripts must be in the `docs` folder to be picked up. I'll follow up with docs if this is good to go.

Resolves https://github.com/docpress/docpress-core/issues/82