### PR TITLE
Add Disqus Support

### DIFF
--- a/data/layout.pug
+++ b/data/layout.pug
@@ -1,3 +1,16 @@
+mixin disqus(shortname)
+  #disqus_thread
+  script.
+    var disqus_shortname = '#{shortname}';
+    (function() {
+      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+  noscript
+    | Please enable JavaScript to view the
+    a(href="http://disqus.com/?ref_noscript") comments powered by Disqus.
+
 //- Menu:
 //- renders the menu item recursively
 
@@ -104,4 +117,7 @@ html
         +header-nav
         .markdown-body
           != contents
+          - if (meta.disqus)
+            +disqus(meta.disqus)
+
         +footer-nav(prev, next)

--- a/lib/helpers/noop.js
+++ b/lib/helpers/noop.js
@@ -1,0 +1,4 @@
+function noop () {
+}
+
+module.exports = noop


### PR DESCRIPTION
# Setup

For enable disqus, need to add the correctly metadada at `docpress.json`:

```json
"disqus": {
    "shortname": "kikobeats.com",
    "exclude": "index|bibliography|resources"
  }
```

where:

- shortname: Your disqus shortname for load your comments.
- exclude: Regex pattern for exclude disqus for determinate pages. by default is `index`