### PR TITLE
Updates all dependencies

### DIFF
--- a/css/components/markdown-body.styl
+++ b/css/components/markdown-body.styl
@@ -11,12 +11,43 @@
   overflow: visible
 
 //
-// Markdown overrides
+// Heading overrides:
+// The h2..h6 changes are in line with older Helvetica GitHub look. The larger
+// heading sizes are more appropriate for full-screen docs (rather than GitHub's
+// where readme's are confined in a panel).
 //
 
 .markdown-body
+  &
+    line-height: 1.65
+
+  @media (max-width: 768px)
+    line-height: 1.6
+    font-size: 15px
+
   h1
     font-size: 2.5em
     font-weight: 300
     margin-bottom: .5em
     padding-bottom: .5em
+
+  h2
+    margin-top: 28px
+    font-size: 1.75em
+    line-height: 1.225
+
+  h3, h4, h5, h6
+    line-height: 1.25
+    margin-top: 24px
+
+  h3
+    font-size: 1.5em
+
+  h4
+    font-size: 1.25em
+
+  h5
+    font-size: .875em
+
+  h6
+    font-size: .85em

--- a/css/components/markdown-body.styl
+++ b/css/components/markdown-body.styl
@@ -11,43 +11,48 @@
   overflow: visible
 
 //
-// Heading overrides:
-// The h2..h6 changes are in line with older Helvetica GitHub look. The larger
-// heading sizes are more appropriate for full-screen docs (rather than GitHub's
-// where readme's are confined in a panel).
+// Heading overrides
 //
 
 .markdown-body
   &
     line-height: 1.65
 
+  // Reduce font size in mobile screens
   @media (max-width: 768px)
     line-height: 1.6
     font-size: 15px
 
+  // Primary headings should be larger on sites. No need to stick to small
+  // GitHub's small h1's, which are more appropriate for readme's on their
+  // site, but not in Docpress sites.
   h1
     font-size: 2.5em
     font-weight: 300
     margin-bottom: .5em
     padding-bottom: .5em
 
-  h2
-    margin-top: 28px
-    font-size: 1.75em
-    line-height: 1.225
+  // The h2..h6 changes are in line with older Helvetica GitHub look. The larger
+  // heading sizes are more appropriate for full-screen docs (rather than GitHub's
+  // where readme's are confined in a panel).
+  @media (min-width: 769px)
+    h2
+      margin-top: 28px
+      font-size: 1.75em
+      line-height: 1.225
 
-  h3, h4, h5, h6
-    line-height: 1.25
-    margin-top: 24px
+    h3, h4, h5, h6
+      line-height: 1.25
+      margin-top: 24px
 
-  h3
-    font-size: 1.5em
+    h3
+      font-size: 1.5em
 
-  h4
-    font-size: 1.25em
+    h4
+      font-size: 1.25em
 
-  h5
-    font-size: .875em
+    h5
+      font-size: .875em
 
-  h6
-    font-size: .85em
+    h6
+      font-size: .85em

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,5 @@
 # Example site
 
 Use this site to test the Docpress theme as you make changes. It's a simple metalsmith site; you can use `node metalsmith.js` or [metalsmith-start] (https://www.npmjs.com/package/metalsmith-start).
+
+Make sure to `rm -rf cache/` first, and restart metalstart everytime you change Stylus files.

--- a/example/docs/hello.md
+++ b/example/docs/hello.md
@@ -1,3 +1,24 @@
 # Hello
 
-This is an example app.
+> A broomstick seeing a rough artwork isn't artisanal
+
+A figure of speech isn't nowadays itself, then she is not unripe or a loud coyote building a calling of the wild now.
+
+Nothing was distinctly urban. The snake rushing something had me. We will be them and nothing won't be walking. We will drive ants seeing happy waiters to divine interventions showing women.
+
+## Urban development
+
+A different fingernail did get it. It did learn. He is not you today. We were destructive softly, but on account of the happy elk, he was running. An unglued monkey did color a four-by-four to itself regularly.
+
+* Everything shouldn't speak them to us
+* Days of the week are following
+* Forces of nature building anxious faces
+* Enemies of the state owning everything are changing
+
+## True strawberries
+
+She was standing. The saturated line giving an unanswered park did give the elk starting the artwork to a government agency and the bottom of the ocean felt itself. They will be government agencies. The piece of my mind, pieces of my mind will be gently something. But then again, a lizard starting the cold shoulder is not the depressed cat.
+
+A dish of the day had it, then it gave it for a poor strawberry behind the dawn of a new age. They will be following behind something, but the poor arm will be softly saturated. The compulsive caterpillar hiding the mongoose colored itself to itself and the impossible coconut was not you on a library.
+
+

--- a/index.js
+++ b/index.js
@@ -190,7 +190,12 @@ function relayout (files, ms, done) {
     const scripts = this.scripts.map(relativize(base))
 
     const locals = {
-      base, toc, index, meta, styles, scripts,
+      base,
+      toc,
+      index,
+      meta,
+      styles,
+      scripts,
       prev: prevName && assign({}, index[prevName], { url: base + prevName }),
       next: nextName && assign({}, index[nextName], { url: base + nextName }),
       active: fname

--- a/package.json
+++ b/package.json
@@ -7,32 +7,32 @@
     "url": "https://github.com/docpress/docpress-base/issues"
   },
   "dependencies": {
-    "autoprefixer": "6.3.5",
-    "browserify": "13.0.0",
+    "autoprefixer": "6.4.0",
+    "browserify": "13.1.0",
     "debounce": "1.0.0",
     "dom101": "1.3.0",
-    "github-markdown-css": "2.1.1",
-    "iconfonts": "0.8.0",
-    "normalize.css": "3.0.3",
+    "github-markdown-css": "2.4.0",
+    "iconfonts": "0.9.0",
+    "normalize.css": "4.2.0",
     "nprogress": "0.2.0",
-    "onmount": "1.2.0",
-    "pjax": "0.1.4",
-    "postcss": "5.0.18",
+    "onmount": "1.3.0",
+    "pjax": "0.2.4",
+    "postcss": "5.1.2",
     "pug": "^2.0.0-beta5",
-    "stylus": "0.54.2",
-    "uglifyify": "3.0.1",
+    "stylus": "0.54.5",
+    "uglifyify": "3.0.2",
     "ware": "1.3.0"
   },
   "devDependencies": {
     "docpress-core": "git://github.com/docpress/docpress-core.git#master",
-    "expect": "1.16.0",
+    "expect": "1.20.2",
     "istanbul": "0.4.5",
-    "metalsmith": "2.1.0",
-    "mocha": "2.4.2",
+    "metalsmith": "2.2.0",
+    "mocha": "3.0.2",
     "mocha-clean": "1.0.0",
     "mocha-standard": "1.0.0",
-    "standard": "6.0.8",
-    "superstatic": "4.0.0"
+    "standard": "8.0.0",
+    "superstatic": "4.0.3"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "onmount": "1.3.0",
     "pjax": "0.2.4",
     "postcss": "5.1.2",
-    "pug": "^2.0.0-beta5",
+    "pug": "^2.0.0-beta6",
     "stylus": "0.54.5",
     "uglifyify": "3.0.2",
     "ware": "1.3.0"

--- a/test/fixture/onmount_test.js
+++ b/test/fixture/onmount_test.js
@@ -47,7 +47,6 @@ describe('fixture/onmount:', function () {
     it('works', function () {
       expect(data).toInclude('.markdown-body')
       expect(data).toInclude('.toc-menu')
-      expect(data).toInclude('octicons-anchor')
     })
   })
 


### PR DESCRIPTION
```
 autoprefixer          6.3.5  →   6.4.0
 browserify           13.0.0  →  13.1.0
 github-markdown-css   2.1.1  →   2.4.0
 iconfonts             0.8.0  →   0.9.0
 normalize.css         3.0.3  →   4.2.0
 onmount               1.2.0  →   1.3.0
 pjax                  0.1.4  →   0.2.4
 postcss              5.0.18  →   5.1.2
 stylus               0.54.2  →  0.54.5
 uglifyify             3.0.1  →   3.0.2
 expect               1.16.0  →  1.20.2
 metalsmith            2.1.0  →   2.2.0
 mocha                 2.4.2  →   3.0.2
 standard              6.0.8  →   8.0.0
 superstatic           4.0.0  →   4.0.3
 pug            ^2.0.0-beta5  →  ^2.0.0-beta6
```