### PR TITLE
Fix bug which was causing custom scripts to never be loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ function addJs (files, ms, done) {
       hash(files['assets/script.js'].contents))
 
     // Add user's files
-    let scripts = ms.metadata()
+    let scripts = ms.metadata().scripts
 
     if (Array.isArray(scripts)) {
       let userScripts = scripts.map((location) => {


### PR DESCRIPTION
As previously written, the `scripts` variable was set to the docpress metadata which is an object. For example, this is what I had in my repo:

```js
let scripts = ms.metadata()

// Now scripts is:
// {
//   docs: 'docs',
//   dist: '_docpress',
//   scripts: [ 'chance.js', 'analytics.js' ],
//   github: 'chancejs/chancejs',
//   plugins: { 'docpress-core': {}, 'docpress-base': {} }
// }
```

As a result, checking a few lines lower (on line 126) if `scripts` is an Array would always fail and no scripts would ever be loaded. I'm not sure how this ever worked.

My fix ensures it finds the `scripts` key within the metadata and assigns that to the `scripts` variable so it should properly reference scripts added to the `docpress.json` or in the `package.json` to the `docpress` section.