### PR TITLE
Fix bug where docpress would not load external scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function addJs (files, ms, done) {
     if (Array.isArray(scripts)) {
       let userScripts = scripts.map((location) => {
         // Need to check if local or external
-        let fileUrl = new url.parse(location, false, true)
+        let fileUrl = url.parse(location, false, true)
         if (fileUrl.host === null) {
           // Local url
           let file = files[location]

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const ware = require('ware')
 const fs = require('fs')
 const pug = require('pug')
 const join = require('path').join
+const url = require('url')
 const assign = Object.assign
 
 const hash = require('./lib/hash')
@@ -125,10 +126,18 @@ function addJs (files, ms, done) {
 
     if (Array.isArray(scripts)) {
       let userScripts = scripts.map((location) => {
-        let file = files[location]
-        if (!file.contents) return
-        let fileHash = hash(file.contents)
-        return `${location}?t=${fileHash}`
+        // Need to check if local or external
+        let fileUrl = new url.parse(location, false, true)
+        if (fileUrl.host === null) {
+          // Local url
+          let file = files[location]
+          if (!file.contents) return
+          let fileHash = hash(file.contents)
+          return `${location}?t=${fileHash}`
+        } else {
+          // External url
+          return `${location}`
+        }
       }).filter((url) => !!url)
       this.scripts = this.scripts.concat(userScripts)
     }


### PR DESCRIPTION
Due to the fact that docpress expected all scripts to be in the files array (consisting of local files only), it was not properly adding script tags for external scripts. 

In fact providing an external url would cause docpress to crash with the following error since an external url would not be in the files object:

```js
        if (!file.contents) return
                 ^

TypeError: Cannot read property 'contents' of undefined
    at scripts.map (/Users/victor/Documents/Development/chancejs/node_modules/docpress-base/index.js:134:18)
    at Array.map (native)
    at callback (/Users/victor/Documents/Development/chancejs/node_modules/docpress-base/index.js:128:33)
    at /Users/victor/Documents/Development/chancejs/node_modules/browserify/index.js:778:13
    at ConcatStream.<anonymous> (/Users/victor/Documents/Development/chancejs/node_modules/concat-stream/index.js:36:43)
    at emitNone (events.js:91:20)
    at ConcatStream.emit (events.js:185:7)
    at finishMaybe (/Users/victor/Documents/Development/chancejs/node_modules/concat-stream/node_modules/readable-stream/lib/_stream_writable.js:475:14)
    at endWritable (/Users/victor/Documents/Development/chancejs/node_modules/concat-stream/node_modules/readable-stream/lib/_stream_writable.js:485:3)
    at ConcatStream.Writable.end (/Users/victor/Documents/Development/chancejs/node_modules/concat-stream/node_modules/readable-stream/lib/_stream_writable.js:455:41)
```

This fixes the bug to ensure that Docpress will add a script tag for a scripts at an external url and that it no longer crashes when provided such a url.