### PR TITLE
If Table of Contents link is external, do not try to add base url 

### DIFF
--- a/data/layout.pug
+++ b/data/layout.pug
@@ -17,7 +17,7 @@ mixin disqus(shortname)
 mixin menu(m, depth)
   li.menu-item(class=('-level-' + depth + (m.sections ? ' -parent' : '')))
     if m.url
-      a.link.title(href=(base + m.url + (m.anchor || '')) class=((active === m.url && !m.anchor ? '-active' : '') + (' link-' + m.slug)))= m.title
+      a.link.title(href=(((m.url.match(/^[a-z]+:\/\//) || m.url.match(/^mailto:/) || m.url.match(/^#/)) ? '' : base) + m.url + (m.anchor || '')) class=((active === m.url && !m.anchor ? '-active' : '') + (' link-' + m.slug))  )= m.title
     else if m.title
       span.title= m.title
 


### PR DESCRIPTION
```
* [External Link to Github](https://github.com)
* [Email Me](mailto:andre@test.com)
```

To go with https://github.com/docpress/docpress-core/pull/196 This will allow absolute links in the Table of Contents properly