### PR TITLE
Add padding in markdown-body div

### DIFF
--- a/css/components/markdown-body.styl
+++ b/css/components/markdown-body.styl
@@ -9,6 +9,7 @@
   margin: 0 auto
   max-width: 768px
   overflow: visible
+  padding-bottom: 24px + 16px + $xpad
 
 //
 // Heading overrides


### PR DESCRIPTION
This commit is intended to close issue: #244

Docpress use a div as a footer pagination mechanism for switching
across pages. This div takes a class attribute with `footer-nav`
value. The `footer-nav` div is fixed positioned to allow the div
remain at the bottom of the page. When the screen width is less
than *960px* it overlaps with the `markdown-body` which contains the
main page content. This results in some lines of texts to be
hidden under `footer-nav`. This bug affects all the generated pages.

To solve that issue we added `padding-bottom` css property to
`markdown-body` class to take up space that would have been occupied
by `footer-nav` as if it was in the normal flow.