### PR TITLE
Prevent content from being cut off on mobile

### DIFF
--- a/css/components/doc-layout.styl
+++ b/css/components/doc-layout.styl
@@ -4,6 +4,7 @@
 
   .body
     padding: 16px
+    padding-bottom: 16px + 64px
 
 //
 // Desktop layout


### PR DESCRIPTION
Example document scrolled to bottom on [markdown page](http://docpress.github.io/customization/markdown.html) mobile size (<960px)

| Issue | solution
| --- | ---
| Content cut off on mobile | Added padding to doc-layout body bottom
| <img width="360" alt="image" src="https://user-images.githubusercontent.com/516342/38793783-49ce0ce6-415b-11e8-9bcb-591e35b09a3a.png"> | <img width="360" alt="image" src="https://user-images.githubusercontent.com/516342/38793802-54c29590-415b-11e8-8357-0ab32d40d9f7.png">

> `padding-bottom` property was selected because it is explicitly overridden by desktop styles on line 25 `padding-bottom: 64px + 64px`
